### PR TITLE
Background rendering for Flutter

### DIFF
--- a/flutter_highlight/README.md
+++ b/flutter_highlight/README.md
@@ -44,6 +44,14 @@ class MyWidget extends StatelessWidget {
 }
 ```
 
+### Background processing
+
+Processing large amounts of text can be slow. To perform text processing in the background, add a
+`HighlightBackgroundEnvironment` above any `HighlightView`s in your widget tree.
+
+A background isolate will be automatically started in `HighlightBackgroundEnvironment.initState`, and stopped in
+`HighlightBackgroundEnvironment.dispose`.
+
 ## References
 
 - [All available languages](https://github.com/pd4d10/highlight/tree/master/highlight/lib/languages)

--- a/flutter_highlight/example/lib/main.dart
+++ b/flutter_highlight/example/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_highlight/flutter_highlight.dart';
+import 'package:flutter_highlight/flutter_highlight_background.dart';
 import 'package:flutter_highlight/theme_map.dart';
 import 'package:url_launcher/url_launcher.dart';
+
 import 'example_map.dart';
 
 void main() => runApp(MyApp());
@@ -95,14 +97,16 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            HighlightView(
-              exampleMap[language],
-              language: language,
-              theme: themeMap[theme],
-              padding: EdgeInsets.all(12),
-              textStyle: TextStyle(
-                  fontFamily:
-                      'SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace'),
+            HighlightBackgroundEnvironment(
+              child: HighlightView(
+                exampleMap[language],
+                language: language,
+                theme: themeMap[theme],
+                padding: EdgeInsets.all(12),
+                textStyle: TextStyle(
+                    fontFamily:
+                        'SFMono-Regular,Consolas,Liberation Mono,Menlo,monospace'),
+              ),
             )
           ],
         ),

--- a/flutter_highlight/lib/flutter_highlight.dart
+++ b/flutter_highlight/lib/flutter_highlight.dart
@@ -50,6 +50,7 @@ class HighlightView extends StatefulWidget {
 }
 
 class _HighlightViewState extends State<HighlightView> {
+  late List<Node> _nodes;
   late List<TextSpan> _spans;
 
   List<TextSpan> _convert(List<Node> nodes) {
@@ -85,12 +86,15 @@ class _HighlightViewState extends State<HighlightView> {
     return spans;
   }
 
-  void _generateSpans() => _spans = _convert(
-      highlight.parse(widget.source, language: widget.language).nodes!);
+  void _parse() =>
+      _nodes = highlight.parse(widget.source, language: widget.language).nodes!;
+
+  void _generateSpans() => _spans = _convert(_nodes);
 
   @override
   void initState() {
     super.initState();
+    _parse();
     _generateSpans();
   }
 
@@ -98,8 +102,10 @@ class _HighlightViewState extends State<HighlightView> {
   void didUpdateWidget(HighlightView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.source != oldWidget.source ||
-        widget.language != oldWidget.language ||
-        widget.theme != oldWidget.theme) {
+        widget.language != oldWidget.language) {
+      _parse();
+      _generateSpans();
+    } else if (widget.theme != oldWidget.theme) {
       _generateSpans();
     }
   }

--- a/flutter_highlight/lib/flutter_highlight.dart
+++ b/flutter_highlight/lib/flutter_highlight.dart
@@ -31,7 +31,7 @@ class HighlightView extends StatefulWidget {
   ///
   /// A widget that is displayed while the [source] is being processed.
   /// This may only be used if a [HighlightBackgroundEnvironment] is available.
-  Widget? progressIndicator;
+  final Widget? progressIndicator;
 
   HighlightView(
     String input, {

--- a/flutter_highlight/lib/flutter_highlight.dart
+++ b/flutter_highlight/lib/flutter_highlight.dart
@@ -3,7 +3,7 @@ import 'package:flutter/widgets.dart';
 import 'package:highlight/highlight.dart' show highlight, Node;
 
 /// Highlight Flutter Widget
-class HighlightView extends StatelessWidget {
+class HighlightView extends StatefulWidget {
   /// The original code to be highlighted
   final String source;
 
@@ -36,6 +36,22 @@ class HighlightView extends StatelessWidget {
     int tabSize = 8, // TODO: https://github.com/flutter/flutter/issues/50087
   }) : source = input.replaceAll('\t', ' ' * tabSize);
 
+  static const _rootKey = 'root';
+  static const _defaultFontColor = Color(0xff000000);
+  static const _defaultBackgroundColor = Color(0xffffffff);
+
+  // TODO: dart:io is not available at web platform currently
+  // See: https://github.com/flutter/flutter/issues/39998
+  // So we just use monospace here for now
+  static const _defaultFontFamily = 'monospace';
+
+  @override
+  State<HighlightView> createState() => _HighlightViewState();
+}
+
+class _HighlightViewState extends State<HighlightView> {
+  late List<TextSpan> _spans;
+
   List<TextSpan> _convert(List<Node> nodes) {
     List<TextSpan> spans = [];
     var currentSpans = spans;
@@ -45,10 +61,11 @@ class HighlightView extends StatelessWidget {
       if (node.value != null) {
         currentSpans.add(node.className == null
             ? TextSpan(text: node.value)
-            : TextSpan(text: node.value, style: theme[node.className!]));
+            : TextSpan(text: node.value, style: widget.theme[node.className!]));
       } else if (node.children != null) {
         List<TextSpan> tmp = [];
-        currentSpans.add(TextSpan(children: tmp, style: theme[node.className!]));
+        currentSpans
+            .add(TextSpan(children: tmp, style: widget.theme[node.className!]));
         stack.add(currentSpans);
         currentSpans = tmp;
 
@@ -68,32 +85,44 @@ class HighlightView extends StatelessWidget {
     return spans;
   }
 
-  static const _rootKey = 'root';
-  static const _defaultFontColor = Color(0xff000000);
-  static const _defaultBackgroundColor = Color(0xffffffff);
+  void _generateSpans() => _spans = _convert(
+      highlight.parse(widget.source, language: widget.language).nodes!);
 
-  // TODO: dart:io is not available at web platform currently
-  // See: https://github.com/flutter/flutter/issues/39998
-  // So we just use monospace here for now
-  static const _defaultFontFamily = 'monospace';
+  @override
+  void initState() {
+    super.initState();
+    _generateSpans();
+  }
+
+  @override
+  void didUpdateWidget(HighlightView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.source != oldWidget.source ||
+        widget.language != oldWidget.language ||
+        widget.theme != oldWidget.theme) {
+      _generateSpans();
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
     var _textStyle = TextStyle(
-      fontFamily: _defaultFontFamily,
-      color: theme[_rootKey]?.color ?? _defaultFontColor,
+      fontFamily: HighlightView._defaultFontFamily,
+      color: widget.theme[HighlightView._rootKey]?.color ??
+          HighlightView._defaultFontColor,
     );
-    if (textStyle != null) {
-      _textStyle = _textStyle.merge(textStyle);
+    if (widget.textStyle != null) {
+      _textStyle = _textStyle.merge(widget.textStyle);
     }
 
     return Container(
-      color: theme[_rootKey]?.backgroundColor ?? _defaultBackgroundColor,
-      padding: padding,
+      color: widget.theme[HighlightView._rootKey]?.backgroundColor ??
+          HighlightView._defaultBackgroundColor,
+      padding: widget.padding,
       child: RichText(
         text: TextSpan(
           style: _textStyle,
-          children: _convert(highlight.parse(source, language: language).nodes!),
+          children: _spans,
         ),
       ),
     );

--- a/flutter_highlight/lib/flutter_highlight.dart
+++ b/flutter_highlight/lib/flutter_highlight.dart
@@ -112,12 +112,26 @@ class _HighlightViewState extends State<HighlightView> {
                   HighlightView.render(nodes, widget.theme))
               as FutureOr<List<TextSpan>>);
 
+  void _parseAndRender(HighlightBackgroundProvider? backgroundProvider) {
+    if (backgroundProvider == null) {
+      _parse(null);
+      _render(null);
+    } else {
+      final resultFuture = backgroundProvider.parseAndRender(
+        widget.source,
+        widget.theme,
+        language: widget.language,
+      );
+      _nodesFuture = resultFuture.then((result) => result.nodes);
+      _spansFuture = resultFuture.then((result) => result.spans);
+    }
+  }
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     final backgroundProvider = HighlightBackgroundProvider.maybeOf(context);
-    _parse(backgroundProvider);
-    _render(backgroundProvider);
+    _parseAndRender(backgroundProvider);
   }
 
   @override
@@ -126,8 +140,7 @@ class _HighlightViewState extends State<HighlightView> {
     if (widget.source != oldWidget.source ||
         widget.language != oldWidget.language) {
       final backgroundProvider = HighlightBackgroundProvider.maybeOf(context);
-      _parse(backgroundProvider);
-      _render(backgroundProvider);
+      _parseAndRender(backgroundProvider);
     } else if (widget.theme != oldWidget.theme) {
       final backgroundProvider = HighlightBackgroundProvider.maybeOf(context);
       _render(backgroundProvider);

--- a/flutter_highlight/lib/flutter_highlight.dart
+++ b/flutter_highlight/lib/flutter_highlight.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/widgets.dart';
 import 'package:flutter_highlight/flutter_highlight_background.dart';
 import 'package:highlight/highlight.dart' show highlight, Node;
@@ -104,15 +106,18 @@ class _HighlightViewState extends State<HighlightView> {
             highlight.parse(widget.source, language: widget.language).nodes,
           );
 
-  void _render() => _spansFuture =
-      _nodesFuture.then((nodes) => HighlightView.render(nodes, widget.theme));
+  void _render(HighlightBackgroundProvider? backgroundProvider) =>
+      _spansFuture = _nodesFuture.then((nodes) =>
+          (backgroundProvider?.render(nodes, widget.theme) ??
+                  HighlightView.render(nodes, widget.theme))
+              as FutureOr<List<TextSpan>>);
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     final backgroundProvider = HighlightBackgroundProvider.maybeOf(context);
     _parse(backgroundProvider);
-    _render();
+    _render(backgroundProvider);
   }
 
   @override
@@ -122,9 +127,10 @@ class _HighlightViewState extends State<HighlightView> {
         widget.language != oldWidget.language) {
       final backgroundProvider = HighlightBackgroundProvider.maybeOf(context);
       _parse(backgroundProvider);
-      _render();
+      _render(backgroundProvider);
     } else if (widget.theme != oldWidget.theme) {
-      _render();
+      final backgroundProvider = HighlightBackgroundProvider.maybeOf(context);
+      _render(backgroundProvider);
     }
   }
 

--- a/flutter_highlight/lib/flutter_highlight.dart
+++ b/flutter_highlight/lib/flutter_highlight.dart
@@ -54,13 +54,13 @@ class HighlightView extends StatefulWidget {
 
   @override
   State<HighlightView> createState() => _HighlightViewState();
-}
 
-class _HighlightViewState extends State<HighlightView> {
-  late Future<List<Node>> _nodesFuture;
-  late Future<List<TextSpan>> _spansFuture;
-
-  List<TextSpan> _convert(List<Node> nodes) {
+  /// Renders a list of [nodes] into a list of [TextSpan]s using the given
+  /// [theme].
+  static List<TextSpan> render(
+    List<Node> nodes,
+    Map<String, TextStyle> theme,
+  ) {
     List<TextSpan> spans = [];
     var currentSpans = spans;
     List<List<TextSpan>> stack = [];
@@ -69,11 +69,11 @@ class _HighlightViewState extends State<HighlightView> {
       if (node.value != null) {
         currentSpans.add(node.className == null
             ? TextSpan(text: node.value)
-            : TextSpan(text: node.value, style: widget.theme[node.className!]));
+            : TextSpan(text: node.value, style: theme[node.className!]));
       } else if (node.children != null) {
         List<TextSpan> tmp = [];
         currentSpans
-            .add(TextSpan(children: tmp, style: widget.theme[node.className!]));
+            .add(TextSpan(children: tmp, style: theme[node.className!]));
         stack.add(currentSpans);
         currentSpans = tmp;
 
@@ -92,6 +92,11 @@ class _HighlightViewState extends State<HighlightView> {
 
     return spans;
   }
+}
+
+class _HighlightViewState extends State<HighlightView> {
+  late Future<List<Node>> _nodesFuture;
+  late Future<List<TextSpan>> _spansFuture;
 
   void _parse(HighlightBackgroundProvider? backgroundProvider) => _nodesFuture =
       backgroundProvider?.parse(widget.source, language: widget.language) ??
@@ -99,14 +104,15 @@ class _HighlightViewState extends State<HighlightView> {
             highlight.parse(widget.source, language: widget.language).nodes,
           );
 
-  void _generateSpans() => _spansFuture = _nodesFuture.then(_convert);
+  void _render() => _spansFuture =
+      _nodesFuture.then((nodes) => HighlightView.render(nodes, widget.theme));
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     final backgroundProvider = HighlightBackgroundProvider.maybeOf(context);
     _parse(backgroundProvider);
-    _generateSpans();
+    _render();
   }
 
   @override
@@ -116,9 +122,9 @@ class _HighlightViewState extends State<HighlightView> {
         widget.language != oldWidget.language) {
       final backgroundProvider = HighlightBackgroundProvider.maybeOf(context);
       _parse(backgroundProvider);
-      _generateSpans();
+      _render();
     } else if (widget.theme != oldWidget.theme) {
-      _generateSpans();
+      _render();
     }
   }
 

--- a/flutter_highlight/lib/flutter_highlight_background.dart
+++ b/flutter_highlight/lib/flutter_highlight_background.dart
@@ -41,7 +41,6 @@ class _HighlightBackgroundEnvironmentState
       } else if (message is _IsolateStartedResponse) {
         _sendPortCompleter.complete(message.sendPort);
       } else if (message is _IsolateEndedResponse) {
-        print('Ended');
         receivePort.close();
       }
     });

--- a/flutter_highlight/lib/flutter_highlight_background.dart
+++ b/flutter_highlight/lib/flutter_highlight_background.dart
@@ -1,0 +1,152 @@
+import 'dart:async';
+import 'dart:isolate';
+
+import 'package:flutter/widgets.dart';
+import 'package:highlight/highlight.dart' show highlight, Node;
+
+/// A widget that provides a background [Isolate] to do expensive highlighting
+/// work in.
+///
+/// The [HighlightView] will detect and use the background environment
+/// automatically.
+/// It can also be used manually through the [HighlightBackgroundProvider]
+/// [InheritedWidget].
+class HighlightBackgroundEnvironment extends StatefulWidget {
+  final Widget child;
+
+  const HighlightBackgroundEnvironment({
+    Key? key,
+    required this.child,
+  }) : super(key: key);
+
+  @override
+  State<HighlightBackgroundEnvironment> createState() =>
+      _HighlightBackgroundEnvironmentState();
+}
+
+class _HighlightBackgroundEnvironmentState
+    extends State<HighlightBackgroundEnvironment> {
+  late final Completer<SendPort> _sendPortCompleter;
+  late final StreamController<_ParseResponse> _parseResultStreamController;
+
+  @override
+  void initState() {
+    super.initState();
+    _sendPortCompleter = Completer();
+    _parseResultStreamController = StreamController.broadcast();
+    final receivePort = ReceivePort();
+    receivePort.listen((message) {
+      if (message is _ParseResponse) {
+        _parseResultStreamController.add(message);
+      } else if (message is _IsolateStartedResponse) {
+        _sendPortCompleter.complete(message.sendPort);
+      } else if (message is _IsolateEndedResponse) {
+        print('Ended');
+        receivePort.close();
+      }
+    });
+    Isolate.spawn(_isolateEntrypoint, receivePort.sendPort);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _sendPortCompleter.future
+        .then((sendPort) => sendPort.send(_IsolateEndRequest()));
+  }
+
+  Future<List<Node>> parse(String source, {String? language}) {
+    final identifier = Capability();
+    _sendPortCompleter.future.then((sendPort) =>
+        sendPort.send(_ParseRequest(identifier, source, language: language)));
+    return _parseResultStreamController.stream
+        .firstWhere((message) => identical(message.identifier, identifier))
+        .then((message) => message.nodes);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return HighlightBackgroundProvider._(
+      environmentIdentifier: this,
+      parse: parse,
+      child: widget.child,
+    );
+  }
+}
+
+class HighlightBackgroundProvider extends InheritedWidget {
+  final Object environmentIdentifier;
+  final Future<List<Node>> Function(String source, {String? language}) parse;
+
+  HighlightBackgroundProvider._({
+    Key? key,
+    required this.environmentIdentifier,
+    required this.parse,
+    required Widget child,
+  }) : super(
+          key: key,
+          child: child,
+        );
+
+  @override
+  bool updateShouldNotify(HighlightBackgroundProvider oldWidget) =>
+      !identical(environmentIdentifier, oldWidget.environmentIdentifier);
+
+  static HighlightBackgroundProvider of(BuildContext context) {
+    final backgroundProvider = maybeOf(context);
+    assert(backgroundProvider != null,
+        'No HighlightBackgroundProvider found in context');
+    return backgroundProvider!;
+  }
+
+  static HighlightBackgroundProvider? maybeOf(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<HighlightBackgroundProvider>();
+}
+
+void _isolateEntrypoint(SendPort sendPort) {
+  final receivePort = ReceivePort();
+  receivePort.listen((message) {
+    if (message is _ParseRequest) {
+      final nodes =
+          highlight.parse(message.source, language: message.language).nodes!;
+      sendPort.send(_ParseResponse(message.identifier, nodes));
+    } else if (message is _IsolateEndRequest) {
+      receivePort.close();
+      sendPort.send(const _IsolateEndedResponse());
+    }
+  });
+  sendPort.send(_IsolateStartedResponse(receivePort.sendPort));
+}
+
+abstract class _IsolateRequest {}
+
+class _IsolateEndRequest implements _IsolateRequest {
+  const _IsolateEndRequest();
+}
+
+class _ParseRequest implements _IsolateRequest {
+  final Capability identifier;
+  final String source;
+  final String? language;
+
+  const _ParseRequest(this.identifier, this.source, {this.language});
+}
+
+abstract class _IsolateResponse {}
+
+class _IsolateStartedResponse implements _IsolateResponse {
+  final SendPort sendPort;
+
+  const _IsolateStartedResponse(this.sendPort);
+}
+
+class _IsolateEndedResponse implements _IsolateResponse {
+  const _IsolateEndedResponse();
+}
+
+class _ParseResponse implements _IsolateResponse {
+  final Capability identifier;
+  final List<Node> nodes;
+
+  const _ParseResponse(this.identifier, this.nodes);
+}


### PR DESCRIPTION
This feature builds on the changes made in #34 to also perform the conversion of `List<Node>` to `List<TextSpan>` in the background.